### PR TITLE
Replace dig by getent

### DIFF
--- a/bin/porticron
+++ b/bin/porticron
@@ -116,7 +116,7 @@ fi
 SCRIPT_NAME=$(basename $0)
 : ${FQDN:=$(hostname --fqdn)}
 : ${HOST:=$(hostname -s)}
-IP=$(dig +short ${FQDN} | tr '\n' ' ')
+IP=$(getent hosts ${FQDN} | cut -d ' ' -f 1)
 : ${DATE:=$(date -R)}
 : ${PORTDIR:=$(portageq get_repo_path $(portageq envvar EROOT) gentoo)}
 


### PR DESCRIPTION
net-dns/bind-tools depends now on net-dns/bind since [ 754524d4345dd41ff9e31cba85afb4f104a9815a](https://gitweb.gentoo.org/repo/gentoo.git/commit/?id=754524d4345dd41ff9e31cba85afb4f104a9815a)
It seems overkill to have to install bind server now to resolve hostname to IP.